### PR TITLE
Fix apt package specifier with version

### DIFF
--- a/tasks/Ubuntu.yaml
+++ b/tasks/Ubuntu.yaml
@@ -14,7 +14,7 @@
 
 - name: Install beat
   apt: 
-    name: "{{ beat_name }}{% if beat_version is defined %}-{{ beat_version }}{% endif %}"
+    name: "{{ beat_name }}{% if beat_version is defined %}={{ beat_version }}{% endif %}"
     update_cache: yes
     state: present
   tags: 


### PR DESCRIPTION
Apt uses equality sign (=) as a delimiter to specify version of a package.
