### PR TITLE
Apt cache

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,15 +15,15 @@ Requirements
 Role Variables
 --------------
 
-|   Variable       | required | default           | comments                                               |
-|------------------|----------|-------------------|--------------------------------------------------------|
-| beat_name        |  no      | "metricbeat"      | The name of the beat to install. The list of `supported_beats` is defined in the role vars. |
-| beat_install     |  no      | true              | A flag used to control whether the role should perform installation steps. |
-| beat_config      |  no      |                   | When defined, the child yaml is used to populate the beat's config file. If undefined, the config file is unchanged.`*` |
-| beat_svc_state   |  no      |                   | When defined, corresponds to the desired `state` parameter of Ansible's [Service Module][ansible-service]. |
-| beat_svc_enabled |  no      |                   | When defined, corresponds to the desired `enabled` parameter of Ansible's [Service Module][ansible-service].|
-| beat_cfg_file    |  no      | {{beat_name}}.yml | If defined, sets the name for the config file. |
-| beat_version     |  no      |                   | If defined, will install the specified version. |
+|   Variable           | required | default           | comments                                               |
+|----------------------|----------|-------------------|--------------------------------------------------------|
+| beat_name            |  no      | "metricbeat"      | The name of the beat to install. The list of `supported_beats` is defined in the role vars. |
+| beat_install         |  no      | true              | A flag used to control whether the role should perform installation steps. |
+| beat_config          |  no      |                   | When defined, the child yaml is used to populate the beat's config file. If undefined, the config file is unchanged.`*` |
+| beat_svc_state       |  no      |                   | When defined, corresponds to the desired `state` parameter of Ansible's [Service Module][ansible-service]. |
+| beat_svc_enabled     |  no      |                   | When defined, corresponds to the desired `enabled` parameter of Ansible's [Service Module][ansible-service].|
+| beat_cfg_file        |  no      | {{beat_name}}.yml | If defined, sets the name for the config file. |
+| beat_version         |  no      |                   | If defined, will install the specified version. |
 | apt_cache_valid_time |  no      | 3600              | Corresponds to the desired `cache_valid_time` parameter of Ansible's [Apt Module][ansible-apt]. |
 
 

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ Role Variables
 | beat_svc_enabled |  no      |                   | When defined, corresponds to the desired `enabled` parameter of Ansible's [Service Module][ansible-service].|
 | beat_cfg_file    |  no      | {{beat_name}}.yml | If defined, sets the name for the config file. |
 | beat_version     |  no      |                   | If defined, will install the specified version. |
+| apt_cache_valid_time |  no      | 3600              | Corresponds to the desired `cache_valid_time` parameter of Ansible's [Apt Module][ansible-apt]. |
 
 
 `*`: You are able to use [config file namespacing][namespacing] when defining the `beat_config` variable, but it is not suggested. 
@@ -91,4 +92,5 @@ Author Information
 https://cyverse.org
 
 [ansible-service]: https://docs.ansible.com/ansible/service_module.html
+[ansible-apt]: https://docs.ansible.com/ansible/apt_module.html
 [namespacing]: https://www.elastic.co/guide/en/beats/libbeat/5.0/config-file-format-namespacing.html

--- a/defaults/main.yaml
+++ b/defaults/main.yaml
@@ -6,7 +6,7 @@ beat_cfg_file: "{{ beat_name }}.yml"
 beat_version: 5.0.2
   #beat_svc_state: started
   #beat_svc_enabled: true
-
+apt_cache_valid_time: 3600
 
 
 

--- a/tasks/Ubuntu.yaml
+++ b/tasks/Ubuntu.yaml
@@ -22,6 +22,7 @@
   apt: 
     name: "{{ beat_name }}{% if beat_version is defined %}={{ beat_version }}{% endif %}"
     update_cache: yes
+    cache_valid_time: "{{ apt_cache_valid_time }}"
     state: present
   tags: 
      - install


### PR DESCRIPTION
Use [`cache_valid_time`](http://docs.ansible.com/ansible/apt_module.html) for the `Apt` module. Default valid cache time is 1h.

It has the nice effect of producing `Changed=0` in Ansible summary for 1h when testing idempotency.